### PR TITLE
Anpassungen für die Version 2.4 in Bezug auf Privacy by default

### DIFF
--- a/lib/sfFacebook.class.php
+++ b/lib/sfFacebook.class.php
@@ -175,7 +175,7 @@ class sfFacebook
   public static function getOrCreateUserByFacebookUid($facebook_uid, $isActive = true)
   {
     $fields = self::getApiFields();
-    $facebook_data = sfFacebook::getFacebookApi("/me?fields=" . implode(',', array_unique($fields)));
+    $facebook_data = sfFacebook::getFacebookApi("me?fields=" . implode(',', $fields));
 
     if (is_array($facebook_data) && isset($facebook_data['id']))
     {
@@ -488,7 +488,7 @@ class sfFacebook
   /**
    * @return array
    */
-  protected static function getApiFields()
+  public static function getApiFields()
   {
     $additionalFields = sfConfig::get('app_facebook_user_fields', []);
     $requiredFields = ['email', 'first_name', 'last_name', 'gender'];
@@ -499,6 +499,6 @@ class sfFacebook
       return !empty($val);
     });
 
-    return $fields;
+    return array_unique($fields);
   }
 }

--- a/lib/sfFacebook.class.php
+++ b/lib/sfFacebook.class.php
@@ -20,9 +20,9 @@ class sfFacebook
     $app_id = self::getApiId();
     $application_secret = self::getApiSecret();
     $args = array();
-    
+
     //var_dump('COOKIE: fbs_' . $app_id);
-    
+
     if (!isset($_COOKIE['fbs_' . $app_id]))
     {
       return null;
@@ -75,7 +75,7 @@ class sfFacebook
   }
 
   /**
-   * get the facebook UID 
+   * get the facebook UID
    *
    * @return Integer
    * @author Benjamin Grandfond <benjaming@theodo.fr>
@@ -174,11 +174,9 @@ class sfFacebook
    */
   public static function getOrCreateUserByFacebookUid($facebook_uid, $isActive = true)
   {
-    $facebook_data = sfFacebook::getFacebookApi("me");
-    
-    //var_dump($facebook_data);
-    //var_dump(sprintf("UID: %s | active: %s", $facebook_uid, $isActive));
-    
+    $fields = self::getApiFields();
+    $facebook_data = sfFacebook::getFacebookApi("/me?fields=" . implode(',', array_unique($fields)));
+
     if (is_array($facebook_data) && isset($facebook_data['id']))
     {
     
@@ -236,7 +234,7 @@ class sfFacebook
   {
     // We get the facebook uid
     $fb_uid = self::getUser();
-    
+
     if ($fb_uid)
     {
       if ($create){
@@ -487,4 +485,20 @@ class sfFacebook
     return join('&', $parameter_array);
   }
 
+  /**
+   * @return array
+   */
+  protected static function getApiFields()
+  {
+    $additionalFields = sfConfig::get('app_facebook_user_fields', []);
+    $requiredFields = ['email', 'first_name', 'last_name', 'gender'];
+    $fields = array_merge($requiredFields, $additionalFields);
+
+    // Filter empty fields
+    $fields = array_filter($fields, function ($val) {
+      return !empty($val);
+    });
+
+    return $fields;
+  }
 }

--- a/lib/sfFacebookGuardAdapter.class.php
+++ b/lib/sfFacebookGuardAdapter.class.php
@@ -216,7 +216,8 @@ abstract class sfFacebookGuardAdapter
     
     try
     {
-      $ret = sfFacebook::getFacebookApi("me");
+      $fields = sfFacebook::getApiFields();
+      $ret = sfFacebook::getFacebookApi("me?fields=" . implode(',', $fields));
       //var_dump($ret);
       
       $sfGuardUser->setUsername($ret['name']);

--- a/modules/sfFacebookConnectDemo/templates/indexSuccess.php
+++ b/modules/sfFacebookConnectDemo/templates/indexSuccess.php
@@ -22,7 +22,8 @@ var_dump("APP_ID:".$ret);
 $ret = sfFacebook::getFacebookCookie();
 var_dump($ret);
 
-$ret = sfFacebook::getFacebookApi("me");
+$fields = sfFacebook::getApiFields();
+$ret = sfFacebook::getFacebookApi("me?fields=" . implode(',', $fields));
 var_dump($ret);
 
 $ret = sfFacebook::getFacebookApi("me/picture");


### PR DESCRIPTION
Ab dem 6. Oktober 2015 geben diese Endpunkte in allen früheren API-Versionen leere Arrays zurück. Außerdem werden die Berechtigungen ignoriert, wenn sie im Login-Dialog angefordert werden, und sie werden nicht in Aufrufen des Endpunkts /v2.4/me/permissions zurückgegeben.